### PR TITLE
Fix: corrected YAML indentation in eksctl tutorial

### DIFF
--- a/docs/tutorial.adoc
+++ b/docs/tutorial.adoc
@@ -72,12 +72,12 @@ metadata:
 
 nodeGroups:
    - name: ng-1
-      instanceType: m5.large
-      desiredCapacity: 2
-      minSize: 1
-      maxSize: 3
-      ssh:
-      allow: false
+     instanceType: m5.large
+     desiredCapacity: 2
+     minSize: 1
+     maxSize: 3
+     ssh:
+        allow: false
 ----
 . Customize the configuration:
 ** Update the `region` to match your desired AWS region.


### PR DESCRIPTION
*Description of changes:*
The cluster config yaml file in the tutorial has a missing indentation on the nodegroup ssh permissions, resulting in the following error when running the cluster config validation step (`eksctl create cluster -f cluster.yaml --dry-run
`): `Error: loading config file "cluster.yaml": error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
