### PR TITLE
Fix indentation in EKS cluster configuration example

### DIFF
--- a/docs/tutorial.adoc
+++ b/docs/tutorial.adoc
@@ -67,17 +67,17 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-   name: basic-cluster
-   region: us-west-2
+  name: basic-cluster
+  region: us-west-2
 
 nodeGroups:
-   - name: ng-1
-     instanceType: m5.large
-     desiredCapacity: 2
-     minSize: 1
-     maxSize: 3
-     ssh:
-        allow: false
+  - name: ng-1
+    instanceType: m5.large
+    desiredCapacity: 2
+    minSize: 1
+    maxSize: 3
+    ssh:
+      allow: false
 ----
 . Customize the configuration:
 ** Update the `region` to match your desired AWS region.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 The current implementation returns the error:
> Error: loading config file "cluster.yaml": error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context

Adjusted indentation for YAML configuration in tutorial.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
