### PR TITLE
Update addon configuration conflict resolution notes

### DIFF
--- a/docs/clusters/addons.adoc
+++ b/docs/clusters/addons.adoc
@@ -204,10 +204,9 @@ addons:
 [NOTE]
 ====
 Bear in mind that when addon configuration values are being modified, configuration conflicts will arise.
+Thus, we need to specify how to deal with those by setting the `resolveConflicts` field accordingly.
+As in this scenario we want to modify these values, we'd set `resolveConflicts: overwrite`.
 ====
-
- Thus, we need to specify how to deal with those by setting the `resolveConflicts` field accordingly.
- As in this scenario we want to modify these values, we'd set `resolveConflicts: overwrite`.
 
 Additionally, the get command will now also retrieve `ConfigurationValues` for the addon. e.g.
 


### PR DESCRIPTION
Fixed formatting of the note on config conflict resolution.

*Issue #, if available:*

*Description of changes:*
In the [original version](https://docs.aws.amazon.com/eks/latest/eksctl/addons.html#_working_with_configuration_values), the second sentence about config resolution ("Thus, we need to specify how to deal with those by setting...") was formatted as a code block.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
